### PR TITLE
add instream id for alternatives

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -258,6 +258,8 @@ func decodeLineOfMasterPlaylist(p *MasterPlaylist, state *decodingState, line st
 				alt.Subtitles = v
 			case "URI":
 				alt.URI = v
+			case "INSTREAM-ID":
+				alt.InstreamID = v
 			}
 		}
 		state.alternatives = append(state.alternatives, &alt)

--- a/reader_test.go
+++ b/reader_test.go
@@ -85,8 +85,8 @@ func TestDecodeMasterPlaylistWithAlternatives(t *testing.T) {
 	}
 	// TODO check other values
 	for i, v := range p.Variants {
-		if i == 0 && len(v.Alternatives) != 3 {
-			t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 3", len(v.Alternatives))
+		if i == 0 && len(v.Alternatives) != 4 {
+			t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 4", len(v.Alternatives))
 		}
 		if i == 1 && len(v.Alternatives) != 3 {
 			t.Fatalf("not all alternatives from #EXT-X-MEDIA parsed (has %d but should be 3", len(v.Alternatives))

--- a/sample-playlists/master-with-alternatives.m3u8
+++ b/sample-playlists/master-with-alternatives.m3u8
@@ -2,6 +2,7 @@
 #EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="low",NAME="Main",DEFAULT=YES,URI="low/main/audio-video.m3u8"
 #EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="low",NAME="Centerfield",DEFAULT=NO,URI="low/centerfield/audio-video.m3u8"
 #EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="low",NAME="Dugout",DEFAULT=NO,URI="low/dugout/audio-video.m3u8"
+#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,GROUP-ID="captions",INSTREAM-ID="CC1",NAME="englishembedded",LANGUAGE="en"
 #EXT-X-STREAM-INF:BANDWIDTH=1280000,VIDEO="low"
 low/main/audio-video.m3u8
 #EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="mid",NAME="Main",DEFAULT=YES,URI="mid/main/audio-video.m3u8"

--- a/structure.go
+++ b/structure.go
@@ -183,6 +183,7 @@ type Alternative struct {
 	Forced          string
 	Characteristics string
 	Subtitles       string
+	InstreamID      string
 }
 
 // This structure represents a media segment included in a media playlist.

--- a/writer.go
+++ b/writer.go
@@ -141,6 +141,11 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 					p.buf.WriteString(alt.URI)
 					p.buf.WriteRune('"')
 				}
+				if alt.InstreamID != "" {
+					p.buf.WriteString(",INSTREAM-ID=\"")
+					p.buf.WriteString(alt.InstreamID)
+					p.buf.WriteRune('"')
+				}
 				p.buf.WriteRune('\n')
 			}
 		}

--- a/writer_test.go
+++ b/writer_test.go
@@ -622,6 +622,14 @@ func TestNewMasterPlaylistWithAlternatives(t *testing.T) {
 		Autoselect: "YES",
 		Language:   "english",
 	}
+	captionsAlt := &Alternative{
+		GroupId:    "captions",
+		Type:       "CLOSED-CAPTIONS",
+		Name:       "englishembedded",
+		Default:    true,
+		Language:   "en",
+		InstreamID: "CC1",
+	}
 	p, e := NewMediaPlaylist(3, 5)
 	if e != nil {
 		t.Fatalf("Create media playlist failed: %s", e)
@@ -637,9 +645,16 @@ func TestNewMasterPlaylistWithAlternatives(t *testing.T) {
 	if m.ver != 4 {
 		t.Fatalf("Expected version 4, actual, %d", m.ver)
 	}
-	expected := `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="main",DEFAULT=YES,AUTOSELECT=YES,LANGUAGE="english",URI="800/rendition.m3u8"`
-	if !strings.Contains(m.String(), expected) {
-		t.Fatalf("Master playlist did not contain: %s\nMaster Playlist:\n%v", expected, m.String())
+	expected1 := `#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",NAME="main",DEFAULT=YES,AUTOSELECT=YES,LANGUAGE="english",URI="800/rendition.m3u8"`
+	if !strings.Contains(m.String(), expected1) {
+		t.Fatalf("Master playlist did not contain: %s\nMaster Playlist:\n%v", expected1, m.String())
+	}
+
+	m.Append("chunklist2.m3u8", p, VariantParams{Alternatives: []*Alternative{captionsAlt}})
+
+	expected2 := `#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,GROUP-ID="captions",NAME="englishembedded",DEFAULT=YES,LANGUAGE="en",INSTREAM-ID="CC1"`
+	if !strings.Contains(m.String(), expected2) {
+		t.Fatalf("Master playlist did not contain: %s\nMaster Playlist:\n%v", expected2, m.String())
 	}
 }
 


### PR DESCRIPTION
Based on https://tools.ietf.org/html/rfc8216#section-4.3.4.1, we require INSTREAM-ID to be part of #EXT-X-MEDIA. This change is to support it so that safari/quicktime plays the stream without error.